### PR TITLE
refactor(AGQ-19): Switch quota --all to use errgroup

### DIFF
--- a/cmd/ag-quota/main.go
+++ b/cmd/ag-quota/main.go
@@ -274,7 +274,7 @@ func runQuotaForAllAccounts(ctx context.Context) {
 	var mu sync.Mutex
 
 	for i, acc := range accounts {
-		i, email := i, acc.Email
+		idx, email := i, acc.Email
 		g.Go(func() error {
 			// Create a new client per goroutine to avoid race conditions
 			client := api.NewClient()
@@ -284,7 +284,7 @@ func runQuotaForAllAccounts(ctx context.Context) {
 			}
 
 			mu.Lock()
-			quotaResults[i] = &ui.AccountQuotaResult{
+			quotaResults[idx] = &ui.AccountQuotaResult{
 				Email:        email,
 				QuotaSummary: quotaInfo,
 			}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/oauth2 v0.34.0
+	golang.org/x/sync v0.19.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
 golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -28,7 +29,7 @@ func TestClient_doRequest(t *testing.T) {
 		baseURL:    server.URL,
 	}
 
-	data, err := client.doRequest("GET", "/test", nil)
+	data, err := client.doRequest(context.Background(), "GET", "/test", nil)
 	if err != nil {
 		t.Fatalf("doRequest failed: %v", err)
 	}
@@ -76,7 +77,7 @@ func TestClient_LoadCodeAssist(t *testing.T) {
 		token:      "fake-token", // Set token to avoid EnsureAuthenticated logic which needs actual storage
 	}
 
-	resp, err := client.LoadCodeAssist()
+	resp, err := client.LoadCodeAssist(context.Background())
 	if err != nil {
 		t.Fatalf("LoadCodeAssist failed: %v", err)
 	}


### PR DESCRIPTION
### 🎯 Objective
Mục tiêu của PR này là cải thiện khả năng xử lý song song, quản lý lỗi tập trung và hỗ trợ hủy tác vụ (cancellation) cho lệnh `quota --all` theo chuẩn Go idiom.
### 🛠 Changes
#### 1. API Client Enhancements
- Cập nhật toàn bộ các phương thức trong [internal/api/client.go](cci:7://file:///home/gundamkid/projects/anti-gravity-quota/internal/api/client.go:0:0-0:0) để hỗ trợ `context.Context`.
- Sử dụng `http.NewRequestWithContext` thay cho `http.NewRequest`, giúp ngắt kết nối HTTP ngay lập tức khi context bị hủy.
#### 2. Concurrency Refactoring (`errgroup`)
- Thay thế `sync.WaitGroup` bằng `golang.org/x/sync/errgroup` trong hàm [runQuotaForAllAccounts](cci:1://file:///home/gundamkid/projects/anti-gravity-quota/cmd/ag-quota/main.go:233:0-335:1).
- **Lợi ích**: 
    - Hỗ trợ cơ chế **short-circuiting**: Nếu một goroutine lỗi, các yêu cầu còn lại sẽ được thông báo để dừng lại ngay lập tức.
#### 3. Graceful Termination
- Tích hợp `signal.NotifyContext` vào lệnh `quota` để bắt tín hiệu `Ctrl+C`.
- Đảm bảo CLI thoát sạch sẽ và ngắt toàn bộ các request ngầm khi người dùng yêu cầu dừng.
#### 4. Quality Assurance
- Cập nhật unit tests trong [internal/api/client_test.go](cci:7://file:///home/gundamkid/projects/anti-gravity-quota/internal/api/client_test.go:0:0-0:0) phù hợp với chữ ký hàm mới.
- Chạy `go mod tidy` để thêm dependency `golang.org/x/sync`.